### PR TITLE
Add support to yield values to child components

### DIFF
--- a/examples/90-examples.html
+++ b/examples/90-examples.html
@@ -12,6 +12,7 @@
   <li><example-link num="7">Emoji randomizer (performance example)</example-link></li>
   <li><example-link num="8">Iteration with tracked tabular data</example-link></li>
   <li><example-link num="9">Selectable table</example-link></li>
+  <li><example-link num="10">Provider Component</example-link></li>
 </ol>
 
 <p>This page is also an example.</p>

--- a/examples/conf.json
+++ b/examples/conf.json
@@ -7,7 +7,7 @@
   },
   "90-examples": {
     "title": "Examples",
-    "children": ["example1", "example2", "example3", "example4", "example5", "example6", "example7", "example8", "example9"]
+    "children": ["example1", "example2", "example3", "example4", "example5", "example6", "example7", "example8", "example9", "example10"]
   },
   "example1": {
     "title": "Example One"
@@ -35,5 +35,8 @@
   },
   "example9": {
     "title": "Example Nine"
+  },
+  "example10": {
+    "title": "Example Ten"
   }
 }

--- a/examples/example10.html
+++ b/examples/example10.html
@@ -1,0 +1,69 @@
+<script type="module" src="./scripts/example-source.js"></script>
+
+<h2 class="[ tutorial ] [ subtitle ]">
+  Provider Component
+</h2>
+
+<example-source lang="html">
+
+<ticker-data>
+  <ticker-display></ticker-display>
+</ticker-data>
+
+</example-source>
+
+<h3>TickerData</h3>
+
+<example-source lang="javascript" strip-script>
+
+<script type="module">
+
+import Component from './component.js';
+import { tracked } from './tracking.js';
+
+class TickerData extends Component {
+  static get template() { return null; }
+  constructor() {
+    super();
+    this.count = tracked(0);
+  }
+  connectedCallback() {
+    super.connectedCallback();
+    this.ticker = setInterval(() => this.count++, 1000);
+  }
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this.ticker);
+  }
+  yields() {
+    return { yieldedCount: this.count };
+  }
+}
+TickerData.register();
+
+</script>
+
+</example-source>
+
+<h3>TickerDisplay</h3>
+
+<example-source lang="javascript" strip-script>
+
+<script type="module">
+
+import Component from './component.js';
+
+class TickerDisplay extends Component {
+  static get template() { return '<time></time>'; }
+  render(attrs) {
+    let { yieldedCount } = attrs.tickerData;
+    let el = this.shadow.querySelector('time');
+    el.setAttribute('datetime', `PT${yieldedCount}S`);
+    el.textContent = `${yieldedCount} seconds`;
+  }
+}
+TickerDisplay.register();
+
+</script>
+
+</example-source>

--- a/lib/component.js
+++ b/lib/component.js
@@ -23,11 +23,32 @@ function dasherize(str) {
   return str.replace(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase();
 }
 
+function camelize(str) {
+  return dasherize(str).replace(/-([a-z])/g, (_, g1) => g1.toUpperCase());
+}
+
 function makeTemplateElement(html) {
   if (html === null) { return null; }
   let element = document.createElement('template');
   element.innerHTML = html ?? '';
   return element;
+}
+
+function findYieldables(component) {
+  let attrs = {};
+  let callback = (id, yieldable) => Object.defineProperty(attrs, id, {
+    get() { return yieldable.yields(); }
+  });
+  let event = new CustomEvent('yields', { detail: callback });
+  component.dispatchEvent(event);
+  return attrs;
+}
+
+function yieldsResponder(component) {
+  let groupName = component.getAttribute('id') || camelize(component.tagName);
+  return function({ detail: callback }) {
+    callback(groupName, component);
+  };
 }
 
 /**
@@ -105,7 +126,7 @@ function componentOf(ElementClass) {
         this.shadow = this.attachShadow({ mode: 'open' });
         this.shadow.appendChild(template.content.cloneNode(true));
       }
-      this[RENDER] = memoizeFunction(() => this.render());
+      this[RENDER] = memoizeFunction(() => this.render(findYieldables(this)));
       this[ATTRIBUTE_TAGS] = new Map(
         (this.constructor.observedAttributes ?? []).map(i => [i, createTag()])
       );
@@ -129,6 +150,7 @@ function componentOf(ElementClass) {
      */
     connectedCallback() {
       this.track();
+      this.addEventListener('yields', yieldsResponder(this), true);
       registerRenderer(this[RENDER]);
       scheduleRender();
     }
@@ -200,8 +222,51 @@ function componentOf(ElementClass) {
      *   }
      * }
      * ```
+     *
+     * @param {object} attrs an object with all values which have been
+     * yielded by parent components index by their camelized name or id of the
+     * respective components
      */
     render() {}
+
+    /**
+     * Called during child components' rendering to ask for any yielded values.
+     * This is a method to pass tracked values to other components in it. Most
+     * cases this will be a component that has `null` for a template but it
+     * isn't required. The `render()` and the `yields()` are two separate ways
+     * to react to tracked changes but they can be used together. Anything
+     * returned from this hook will be passed to any child component's
+     * `render()` hook as named argument.
+     *
+     * ```html
+     * <my-provider>
+     *   <my-presenter></my-presenter>
+     * </my-provider>
+     * ```
+     *
+     * ```js
+     * class MyProvider extends Component {
+     *   trackedValue = tracked();
+     *   static get template() { return null; }
+     *   yields() {
+     *     return { yieldedValue: this.trackedValue };
+     *   }
+     * }
+     * MyProvider.register();
+     *
+     * class MyPresenter extends Component {
+     *   render(attrs) {
+     *     let { yieldedValue } = attrs.myProvider;
+     *     this.shadow.textContent = yieldedValue;
+     *   }
+     * }
+     * MyPresenter.register();
+     * ```
+     *
+     * @tutorial example10
+     * @return any
+     */
+    yields() {}
 
     /**
      * Call this static method to define the component as a custom element with the browser.


### PR DESCRIPTION
Prior to this change, there was no good pattern for exchanging tracked data between components. An example in Ember/Vue/React is "provider components"

This change adds support for a `yields()` hook which will return curated data that child components will be able to access via named params passed into the `render()` hook.

```js
class MyProvider extends Component {
  static get template() { return null; }
  foo = tracked();
  yields() {
    return this.foo;
  }
}
MyProvider.register();

class MyPresenter extends Component {
  render(attrs) {
    let { foo } = attrs.myProvider; // camelized class or element ID
    this.shadow.textContent = foo;
  }
}
MyProvider.register();
```

```html
<my-provider>
  <my-presenter></my-presenter>
</my-provider>
```