### PR TITLE
Have hasAttribute consume tags

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -193,6 +193,11 @@ function componentOf(ElementClass) {
       return super.getAttribute(name);
     }
 
+    hasAttribute(name) {
+      consumeTag(this[ATTRIBUTE_TAGS].get(name));
+      return super.hasAttribute(name);
+    }
+
     /**
      * Activate tracking on this component. Called automatically during
      * [.connectedCallback()]{@link module:component~Component#connectedCallback}


### PR DESCRIPTION
Prior to this change, using `hasAttribute` would not consume the `observedAttributes` tags like `getAttribute` does.

This change adds the same tracking to `hasAttribute`.

Fixes #5