### PR TITLE
Add support for yields crossing ShadowDOM barrier

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -36,10 +36,10 @@ function makeTemplateElement(html) {
 
 function findYieldables(component) {
   let attrs = {};
-  let callback = (id, yieldable) => Object.defineProperty(attrs, id, {
+  let detail = (id, yieldable) => Object.defineProperty(attrs, id, {
     get() { return yieldable.yields(); }
   });
-  let event = new CustomEvent('yields', { detail: callback });
+  let event = new CustomEvent('yields', { detail, bubbles: true, composed: true });
   component.dispatchEvent(event);
   return attrs;
 }


### PR DESCRIPTION
Prior to this change, the yields event would bubble/propagate through the LightDOM but the ShadowDOM did not propagate through. This meant that components that used a template which rendered another component the child component would not have access to the parent's yields().

This change adds an event listener to this.shadow as well to capture any components either in the LightDOM or the ShadowDOM.

Fixes #8